### PR TITLE
remove libfltk1.3-dev from FLTK's bench.dockerfile

### DIFF
--- a/toolkits/C++/fltk/bench.dockerfile
+++ b/toolkits/C++/fltk/bench.dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stable-slim
 
-RUN apt-get update && apt-get install -qq --no-install-recommends libx11-6 libxinerama1 libxft2 libxext6 libxcursor1 libxrender1 libxfixes3 libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libpangoxft-1.0-0 libglib2.0-0 libfontconfig1 libfltk1.3-dev
+RUN apt-get update && apt-get install -qq --no-install-recommends libx11-6 libxinerama1 libxft2 libxext6 libxcursor1 libxrender1 libxfixes3 libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libpangoxft-1.0-0 libglib2.0-0 libfontconfig1
 
 CMD /executable/app

--- a/toolkits/C++/fltk/bench.dockerfile
+++ b/toolkits/C++/fltk/bench.dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stable-slim
 
-RUN apt-get update && apt-get install -qq --no-install-recommends libx11-6 libxinerama1 libxft2 libxext6 libxcursor1 libxrender1 libxfixes3 libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libpangoxft-1.0-0 libglib2.0-0 libfontconfig1
+RUN apt-get update && apt-get install -qq --no-install-recommends libx11-6 libxinerama1 libxft2 libxext6 libxcursor1 libxrender1 libxfixes3 libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libpangoxft-1.0-0 libglib2.0-0 libfontconfig1 libfltk1.3
 
 CMD /executable/app

--- a/toolkits/C++/fltk/src/main.cpp
+++ b/toolkits/C++/fltk/src/main.cpp
@@ -4,7 +4,7 @@
 #include <cstdio>
 
 int main() {
-  Fl_Window win(0, 0, 512, 512, "FLTK C++ app");
+  Fl_Double_Window win(0, 0, 512, 512, "FLTK C++ app");
   Fl_Button btn(0, 0, 512, 512, "Click me!");
   btn.callback([](auto){ fputs("Clicked!", stderr); });
   win.end();


### PR DESCRIPTION
This was added by mistake to the bench.dockerfile, it shouldn't be needed, and it just increases the image's size with needless header files.