### PR TITLE
Replace ADD with COPY inside build.dockerfile files

### DIFF
--- a/toolkits/C++/fltk/build.dockerfile
+++ b/toolkits/C++/fltk/build.dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends build-essential libfltk1.3-dev libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libpango1.0-dev libcairo2-dev
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 CMD g++ -s -std=c++17 $(fltk-config --cflags) -o /executable/app src/main.cpp $(fltk-config --libs --ldflags) -O2

--- a/toolkits/C++/qml/build.dockerfile
+++ b/toolkits/C++/qml/build.dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends build-essential qtbase5-dev libqt5widgets5 qtdeclarative5-dev libqt5qml5 libqt5quick5 qml-module-qtquick-controls2 qml-module-qtquick2 qml-module-qtquick-window2
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 # CMD g++ std=c++11 fPIC $(pkg-config --cflags Qt5Widgets) -o /executable/app src/main.cpp $(pkg-config --libs Qt5Widgets)

--- a/toolkits/C++/qt/build.dockerfile
+++ b/toolkits/C++/qt/build.dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends build-essential qtbase5-dev libqt5widgets5
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 # CMD g++ std=c++11 fPIC $(pkg-config --cflags Qt5Widgets) -o /executable/app src/main.cpp $(pkg-config --libs Qt5Widgets)

--- a/toolkits/C++/wxwidgets/build.dockerfile
+++ b/toolkits/C++/wxwidgets/build.dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends build-essential g++ libwxgtk3.2-dev
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 CMD g++ -s `wx-config --cflags` -o /executable/app src/main.cpp `wx-config --libs` -O2

--- a/toolkits/C/gtk/build.dockerfile
+++ b/toolkits/C/gtk/build.dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends pkg-config libglib2.0-dev libgtk-4-dev
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 CMD gcc -s $(pkg-config --cflags gtk4) -o /executable/app src/main.c $(pkg-config --libs gtk4) -O2

--- a/toolkits/Java/swing/build.dockerfile
+++ b/toolkits/Java/swing/build.dockerfile
@@ -2,7 +2,7 @@ FROM debian:stable-slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends default-jdk
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 CMD javac -d /executable src/app.java

--- a/toolkits/Rust/dioxus/build.dockerfile
+++ b/toolkits/Rust/dioxus/build.dockerfile
@@ -2,7 +2,7 @@ FROM rust:slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 RUN cargo clean

--- a/toolkits/Rust/druid/build.dockerfile
+++ b/toolkits/Rust/druid/build.dockerfile
@@ -2,7 +2,7 @@ FROM rust:slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends pkg-config libglib2.0-dev libgtk-3-dev
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 RUN cargo clean

--- a/toolkits/Rust/egui/build.dockerfile
+++ b/toolkits/Rust/egui/build.dockerfile
@@ -2,7 +2,7 @@ FROM rust:slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends libx11-6 libxcursor1 libxrandr-dev libxi6 libx11-xcb1 libclang-dev libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 RUN cargo clean

--- a/toolkits/Rust/fltk-rs/build.dockerfile
+++ b/toolkits/Rust/fltk-rs/build.dockerfile
@@ -2,7 +2,7 @@ FROM rust:slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends build-essential cmake git libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev libxrender-dev libxfixes-dev libpango1.0-dev libcairo2-dev
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 RUN cargo clean

--- a/toolkits/Rust/gtk-rs/build.dockerfile
+++ b/toolkits/Rust/gtk-rs/build.dockerfile
@@ -2,7 +2,7 @@ FROM rust:slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends libgtk-3-dev build-essential
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 RUN cargo clean

--- a/toolkits/Rust/iced/build.dockerfile
+++ b/toolkits/Rust/iced/build.dockerfile
@@ -2,7 +2,7 @@ FROM rust:slim
 
 RUN apt-get update && apt-get install --no-install-recommends -qq cmake make g++ pkg-config libfontconfig-dev libx11-6 libxcursor1 libxrandr-dev libxi6 libx11-xcb-dev libegl-dev
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 RUN cargo clean

--- a/toolkits/Rust/imgui-rs/build.dockerfile
+++ b/toolkits/Rust/imgui-rs/build.dockerfile
@@ -2,7 +2,7 @@ FROM rust:slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends build-essential cmake pkg-config libfontconfig1-dev libx11-6 libxcursor1 libxrandr-dev libxi6 libx11-xcb-dev libegl-dev
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 RUN cargo clean

--- a/toolkits/Rust/tauri/build.dockerfile
+++ b/toolkits/Rust/tauri/build.dockerfile
@@ -2,7 +2,7 @@ FROM rust:slim
 
 RUN apt-get update && apt-get install -qq --no-install-recommends libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev
 
-ADD ./ /workdir
+COPY ./ /workdir
 WORKDIR /workdir
 
 RUN cargo clean


### PR DESCRIPTION
Replaced instances of 'ADD' with 'COPY' in build.dockerfile files to improve Dockerfile best practices and maintain consistency. 

The 'COPY' command is preferred over 'ADD' for copying files into Docker images.
